### PR TITLE
Scaffold Angular base with mock data and services

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,10 @@
+<mat-toolbar color="primary" class="app-toolbar">
+  <span class="app-title">{{ title }}</span>
+  <span class="spacer"></span>
+  <a mat-button routerLink="/songs">Songs</a>
+  <a mat-button routerLink="/snapshots">Snapshots</a>
+</mat-toolbar>
+
+<main class="app-shell">
+  <router-outlet></router-outlet>
+</main>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,16 @@
+.app-toolbar {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.app-title {
+  font-weight: 600;
+}
+
+.spacer {
+  flex: 1 1 auto;
+}
+
+.app-shell {
+  padding: 1rem;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { RouterLink, RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [MatToolbarModule, MatButtonModule, RouterOutlet, RouterLink],
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss'],
+})
+export class AppComponent {
+  readonly title = 'NoteDraftForge';
+}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,0 +1,9 @@
+import { ApplicationConfig } from '@angular/core';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { appRoutes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(appRoutes), provideHttpClient(), provideAnimations()],
+};

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,0 +1,18 @@
+import { Routes } from '@angular/router';
+import { SongListComponent } from './features/songs/song-list/song-list.component';
+import { SongDetailComponent } from './features/songs/song-detail/song-detail.component';
+import { SnapshotBuilderComponent } from './features/snapshots/snapshot-builder/snapshot-builder.component';
+
+export const appRoutes: Routes = [
+  {
+    path: 'songs',
+    component: SongListComponent,
+    children: [{ path: ':id', component: SongDetailComponent }],
+  },
+  {
+    path: 'snapshots',
+    component: SnapshotBuilderComponent,
+  },
+  { path: '', pathMatch: 'full', redirectTo: 'songs' },
+  { path: '**', redirectTo: 'songs' },
+];

--- a/src/app/core/models/author.ts
+++ b/src/app/core/models/author.ts
@@ -1,0 +1,5 @@
+export interface Author {
+  id: string;
+  name: string;
+  alias?: string;
+}

--- a/src/app/core/models/lang.ts
+++ b/src/app/core/models/lang.ts
@@ -1,0 +1,5 @@
+export type LangCode = 'es' | 'en' | 'ca' | 'fr';
+
+export interface MultilangText {
+  [lang: string]: string;
+}

--- a/src/app/core/models/singer.ts
+++ b/src/app/core/models/singer.ts
@@ -1,0 +1,4 @@
+export interface Singer {
+  id: string;
+  name: string;
+}

--- a/src/app/core/models/song.ts
+++ b/src/app/core/models/song.ts
@@ -1,0 +1,31 @@
+import { MultilangText } from './lang';
+import { StyleId } from './style';
+
+export interface SongBlock {
+  chord?: string;
+  melody?: string;
+  lyrics: MultilangText;
+}
+
+export interface SongLine {
+  blocks: SongBlock[];
+}
+
+export interface SongSection {
+  name: string;
+  lines: SongLine[];
+}
+
+export interface Song {
+  id: string;
+  title: MultilangText;
+  authorId: string;
+  styleId: StyleId;
+  rhythm?: string;
+  baseKey: string;
+  singers: string[];
+  tags?: string[];
+  song: {
+    sections: SongSection[];
+  };
+}

--- a/src/app/core/models/style.ts
+++ b/src/app/core/models/style.ts
@@ -1,0 +1,13 @@
+export type StyleId =
+  | 'pop'
+  | 'rock'
+  | 'rumba'
+  | 'balada'
+  | 'latin'
+  | 'flamenco'
+  | 'others';
+
+export interface Style {
+  id: StyleId;
+  label: string;
+}

--- a/src/app/core/models/user.ts
+++ b/src/app/core/models/user.ts
@@ -1,0 +1,7 @@
+export interface User {
+  id: string;
+  name: string;
+  email?: string;
+  avatarUrl?: string;
+  provider?: string;
+}

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { User } from '../models/user';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly user$ = new BehaviorSubject<User | null>(null);
+
+  constructor() {
+    if (!environment.production) {
+      this.loginWith('local-dev');
+    }
+  }
+
+  get currentUser$(): Observable<User | null> {
+    return this.user$.asObservable();
+  }
+
+  loginWith(provider: string): void {
+    const fakeUser: User = {
+      id: 'dev-user',
+      name: 'Dev User',
+      provider,
+    };
+    this.user$.next(fakeUser);
+  }
+
+  logout(): void {
+    this.user$.next(null);
+  }
+}

--- a/src/app/core/services/library.service.ts
+++ b/src/app/core/services/library.service.ts
@@ -1,0 +1,71 @@
+import { inject, Injectable } from '@angular/core';
+import { BehaviorSubject, filter, map, Observable, of, shareReplay, take, tap } from 'rxjs';
+import { SongDataService, LibraryPayload } from './song-data.service';
+import { Song } from '../models/song';
+import { Author } from '../models/author';
+import { Singer } from '../models/singer';
+import { Style } from '../models/style';
+
+@Injectable({ providedIn: 'root' })
+export class LibraryService {
+  private readonly songDataService = inject(SongDataService);
+  private readonly library$ = new BehaviorSubject<LibraryPayload | null>(null);
+  private initialized = false;
+
+  init(): Observable<LibraryPayload> {
+    if (this.initialized) {
+      return this.library$.pipe(filter((data): data is LibraryPayload => !!data), take(1));
+    }
+
+    return this.songDataService.loadLibrary().pipe(
+      tap((payload) => {
+        this.library$.next(payload);
+        this.initialized = true;
+      }),
+      shareReplay(1)
+    );
+  }
+
+  private select<K extends keyof LibraryPayload>(key: K): Observable<LibraryPayload[K]> {
+    return this.library$.pipe(
+      filter((data): data is LibraryPayload => !!data),
+      map((data) => data[key])
+    );
+  }
+
+  getLibrary(): Observable<LibraryPayload> {
+    return this.library$.pipe(filter((data): data is LibraryPayload => !!data));
+  }
+
+  getSongs(): Observable<Song[]> {
+    return this.select('songs');
+  }
+
+  getSongById(id: string): Observable<Song | undefined> {
+    return this.getSongs().pipe(map((songs) => songs.find((song) => song.id === id)));
+  }
+
+  getAuthors(): Observable<Author[]> {
+    return this.select('authors');
+  }
+
+  getAuthorById(id: string): Observable<Author | undefined> {
+    return this.getAuthors().pipe(map((authors) => authors.find((author) => author.id === id)));
+  }
+
+  getSingers(): Observable<Singer[]> {
+    return this.select('singers');
+  }
+
+  getSingerById(id: string): Observable<Singer | undefined> {
+    return this.getSingers().pipe(map((singers) => singers.find((singer) => singer.id === id)));
+  }
+
+  getStyles(): Observable<Style[]> {
+    return this.select('styles');
+  }
+
+  getStyleById(id: string): Observable<Style | undefined> {
+    return this.getStyles().pipe(map((styles) => styles.find((style) => style.id === id)));
+  }
+}

--- a/src/app/core/services/song-data.service.ts
+++ b/src/app/core/services/song-data.service.ts
@@ -1,0 +1,29 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { forkJoin, Observable } from 'rxjs';
+import { Song } from '../models/song';
+import { Author } from '../models/author';
+import { Singer } from '../models/singer';
+import { Style } from '../models/style';
+
+export interface LibraryPayload {
+  songs: Song[];
+  authors: Author[];
+  singers: Singer[];
+  styles: Style[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class SongDataService {
+  private readonly http = inject(HttpClient);
+  private readonly basePath = 'assets/mock';
+
+  loadLibrary(): Observable<LibraryPayload> {
+    const songs$ = this.http.get<Song[]>(`${this.basePath}/songs.json`);
+    const authors$ = this.http.get<Author[]>(`${this.basePath}/authors.json`);
+    const singers$ = this.http.get<Singer[]>(`${this.basePath}/singers.json`);
+    const styles$ = this.http.get<Style[]>(`${this.basePath}/styles.json`);
+
+    return forkJoin({ songs: songs$, authors: authors$, singers: singers$, styles: styles$ });
+  }
+}

--- a/src/app/features/snapshots/snapshot-builder/snapshot-builder.component.html
+++ b/src/app/features/snapshots/snapshot-builder/snapshot-builder.component.html
@@ -1,0 +1,23 @@
+<section class="snapshot-builder">
+  <header>
+    <h2>Snapshot Builder</h2>
+    <p>Select songs to include in a printable snapshot.</p>
+  </header>
+
+  <mat-selection-list>
+    <mat-list-option
+      *ngFor="let song of songs$ | async"
+      [selected]="(selectionState$ | async)?.has(song.id)"
+      (selectionChange)="toggleSong(song)"
+    >
+      {{ songTitle(song) }}
+    </mat-list-option>
+  </mat-selection-list>
+
+  <div class="actions">
+    <button mat-stroked-button color="primary" (click)="clearSelection()">Clear selection</button>
+    <div class="summary">
+      <strong>Selected:</strong> {{ (selectedSongs$ | async)?.length || 0 }}
+    </div>
+  </div>
+</section>

--- a/src/app/features/snapshots/snapshot-builder/snapshot-builder.component.scss
+++ b/src/app/features/snapshots/snapshot-builder/snapshot-builder.component.scss
@@ -1,0 +1,21 @@
+.snapshot-builder {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+header {
+  margin-bottom: 0.75rem;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.summary {
+  color: #555;
+}

--- a/src/app/features/snapshots/snapshot-builder/snapshot-builder.component.ts
+++ b/src/app/features/snapshots/snapshot-builder/snapshot-builder.component.ts
@@ -1,0 +1,54 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { MatListModule } from '@angular/material/list';
+import { MatButtonModule } from '@angular/material/button';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { BehaviorSubject, map } from 'rxjs';
+import { LibraryService } from '../../../core/services/library.service';
+import { Song } from '../../../core/models/song';
+import { LangCode } from '../../../core/models/lang';
+
+@Component({
+  selector: 'app-snapshot-builder',
+  standalone: true,
+  imports: [CommonModule, MatListModule, MatButtonModule],
+  templateUrl: './snapshot-builder.component.html',
+  styleUrls: ['./snapshot-builder.component.scss'],
+})
+export class SnapshotBuilderComponent implements OnInit {
+  private readonly library = inject(LibraryService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly selection$ = new BehaviorSubject<Set<string>>(new Set());
+
+  readonly displayLang: LangCode = 'en';
+  readonly songs$ = this.library.getSongs();
+  readonly selectionState$ = this.selection$.asObservable();
+  readonly selectedSongs$ = this.selection$.pipe(
+    map((selection) => Array.from(selection))
+  );
+
+  ngOnInit(): void {
+    this.library
+      .init()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
+  songTitle(song: Song): string {
+    return song.title[this.displayLang] ?? Object.values(song.title)[0] ?? 'Untitled';
+  }
+
+  toggleSong(song: Song): void {
+    const next = new Set(this.selection$.value);
+    if (next.has(song.id)) {
+      next.delete(song.id);
+    } else {
+      next.add(song.id);
+    }
+    this.selection$.next(next);
+  }
+
+  clearSelection(): void {
+    this.selection$.next(new Set());
+  }
+}

--- a/src/app/features/songs/song-detail/song-detail.component.html
+++ b/src/app/features/songs/song-detail/song-detail.component.html
@@ -1,0 +1,30 @@
+<section *ngIf="song$ | async as song; else notFound" class="song-detail">
+  <header class="song-header">
+    <h2>{{ songTitle(song) }}</h2>
+    <p class="meta">
+      <span>Key: {{ song.baseKey }}</span>
+      <span>Style: {{ song.styleId }}</span>
+      <span *ngIf="song.rhythm">Rhythm: {{ song.rhythm }}</span>
+    </p>
+  </header>
+
+  <div class="song-body">
+    <div class="section" *ngFor="let section of song.song.sections">
+      <h3>{{ section.name }}</h3>
+      <div class="line" *ngFor="let line of section.lines">
+        <div
+          class="block"
+          *ngFor="let block of line.blocks; let i = index"
+          [class.chord-change]="hasChordChange(block, line.blocks[i - 1])"
+        >
+          <div class="chord" *ngIf="block.chord">{{ block.chord }}</div>
+          <div class="lyrics">{{ blockLyrics(block) }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<ng-template #notFound>
+  <p class="placeholder">Song not found. Pick another one from the list.</p>
+</ng-template>

--- a/src/app/features/songs/song-detail/song-detail.component.scss
+++ b/src/app/features/songs/song-detail/song-detail.component.scss
@@ -1,0 +1,62 @@
+.song-detail {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.song-header {
+  margin-bottom: 1rem;
+}
+
+.song-header h2 {
+  margin: 0 0 0.25rem;
+}
+
+.meta {
+  display: flex;
+  gap: 1rem;
+  color: #666;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.section {
+  margin-bottom: 1rem;
+}
+
+.section h3 {
+  margin-bottom: 0.5rem;
+}
+
+.line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.block {
+  padding: 0.35rem 0.5rem;
+  border-radius: 4px;
+  background: #f5f5f5;
+  min-width: 120px;
+}
+
+.block .chord {
+  font-weight: 600;
+  color: #3f51b5;
+}
+
+.block .lyrics {
+  margin-top: 0.15rem;
+}
+
+.chord-change {
+  border: 1px solid #3f51b5;
+  box-shadow: 0 0 0 2px rgba(63, 81, 181, 0.1);
+}
+
+.placeholder {
+  color: #777;
+}

--- a/src/app/features/songs/song-detail/song-detail.component.ts
+++ b/src/app/features/songs/song-detail/song-detail.component.ts
@@ -1,0 +1,41 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { combineLatest, map, switchMap } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { LibraryService } from '../../../core/services/library.service';
+import { Song, SongBlock } from '../../../core/models/song';
+import { LangCode } from '../../../core/models/lang';
+
+@Component({
+  selector: 'app-song-detail',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './song-detail.component.html',
+  styleUrls: ['./song-detail.component.scss'],
+})
+export class SongDetailComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly library = inject(LibraryService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly displayLang: LangCode = 'en';
+
+  readonly song$ = this.route.paramMap.pipe(
+    map((params) => params.get('id')),
+    switchMap((id) => this.library.getSongById(id ?? '')),
+    takeUntilDestroyed(this.destroyRef)
+  );
+
+  songTitle(song: Song): string {
+    return song.title[this.displayLang] ?? Object.values(song.title)[0] ?? 'Untitled';
+  }
+
+  blockLyrics(block: SongBlock): string {
+    return block.lyrics[this.displayLang] ?? Object.values(block.lyrics)[0] ?? '';
+  }
+
+  hasChordChange(block: SongBlock, previous?: SongBlock): boolean {
+    return !!block.chord && block.chord !== previous?.chord;
+  }
+}

--- a/src/app/features/songs/song-list/song-list.component.html
+++ b/src/app/features/songs/song-list/song-list.component.html
@@ -1,0 +1,24 @@
+<mat-sidenav-container class="song-shell">
+  <mat-sidenav mode="side" opened class="song-nav">
+    <h3 class="nav-title">Songs</h3>
+    <mat-nav-list>
+      <a
+        mat-list-item
+        *ngFor="let song of songs$ | async"
+        [routerLink]="['/songs', song.id]"
+        routerLinkActive="active-link"
+      >
+        <mat-icon matListItemIcon>music_note</mat-icon>
+        <div matListItemTitle>{{ songTitle(song) }}</div>
+        <div matListItemLine>Key: {{ song.baseKey }}</div>
+      </a>
+    </mat-nav-list>
+  </mat-sidenav>
+
+  <mat-sidenav-content class="song-content">
+    <router-outlet #detailOutlet="routerOutlet"></router-outlet>
+    <div *ngIf="!detailOutlet.isActivated" class="placeholder">
+      Select a song to view its details.
+    </div>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/src/app/features/songs/song-list/song-list.component.scss
+++ b/src/app/features/songs/song-list/song-list.component.scss
@@ -1,0 +1,30 @@
+.song-shell {
+  height: calc(100vh - 64px);
+  border: 1px solid #e0e0e0;
+}
+
+.song-nav {
+  width: 280px;
+  padding: 0.5rem 0.75rem;
+  border-right: 1px solid #e0e0e0;
+}
+
+.nav-title {
+  margin: 0 0 0.5rem 0;
+  font-weight: 600;
+}
+
+.song-content {
+  padding: 1rem;
+  background: #fafafa;
+}
+
+.placeholder {
+  color: #666;
+  font-style: italic;
+  margin-top: 1rem;
+}
+
+.active-link {
+  background-color: rgba(63, 81, 181, 0.08);
+}

--- a/src/app/features/songs/song-list/song-list.component.ts
+++ b/src/app/features/songs/song-list/song-list.component.ts
@@ -1,0 +1,44 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatListModule } from '@angular/material/list';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { LibraryService } from '../../../core/services/library.service';
+import { Song } from '../../../core/models/song';
+import { LangCode } from '../../../core/models/lang';
+
+@Component({
+  selector: 'app-song-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    RouterLinkActive,
+    RouterOutlet,
+    MatSidenavModule,
+    MatListModule,
+    MatIconModule,
+  ],
+  templateUrl: './song-list.component.html',
+  styleUrls: ['./song-list.component.scss'],
+})
+export class SongListComponent implements OnInit {
+  private readonly library = inject(LibraryService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly displayLang: LangCode = 'en';
+  readonly songs$ = this.library.getSongs();
+
+  ngOnInit(): void {
+    this.library
+      .init()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
+  songTitle(song: Song): string {
+    return song.title[this.displayLang] ?? Object.values(song.title)[0] ?? 'Untitled';
+  }
+}

--- a/src/assets/mock/authors.json
+++ b/src/assets/mock/authors.json
@@ -1,0 +1,4 @@
+[
+  { "id": "author-1", "name": "Lucia Romero", "alias": "L. Ro" },
+  { "id": "author-2", "name": "Max Turner" }
+]

--- a/src/assets/mock/singers.json
+++ b/src/assets/mock/singers.json
@@ -1,0 +1,4 @@
+[
+  { "id": "singer-1", "name": "Aina Sol" },
+  { "id": "singer-2", "name": "Theo Rivers" }
+]

--- a/src/assets/mock/songs.json
+++ b/src/assets/mock/songs.json
@@ -1,0 +1,140 @@
+[
+  {
+    "id": "song-001",
+    "title": {
+      "en": "Sunrise Echoes",
+      "es": "Ecos del Amanecer",
+      "fr": "Échos de l'aube"
+    },
+    "authorId": "author-1",
+    "styleId": "pop",
+    "rhythm": "4/4",
+    "baseKey": "C",
+    "singers": ["singer-1", "singer-2"],
+    "tags": ["upbeat", "acoustic"],
+    "song": {
+      "sections": [
+        {
+          "name": "Verse",
+          "lines": [
+            {
+              "blocks": [
+                {
+                  "chord": "C",
+                  "lyrics": {
+                    "en": "Walking with the morning light",
+                    "es": "Caminando con la luz del alba"
+                  }
+                },
+                {
+                  "chord": "G",
+                  "lyrics": {
+                    "en": "golden streets ahead",
+                    "es": "calles doradas delante"
+                  }
+                },
+                {
+                  "chord": "Am",
+                  "lyrics": {
+                    "en": "every step a rising song",
+                    "es": "cada paso una canción al elevar"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Chorus",
+          "lines": [
+            {
+              "blocks": [
+                {
+                  "chord": "F",
+                  "lyrics": {
+                    "en": "Hold the light inside",
+                    "es": "Guarda la luz dentro"
+                  }
+                },
+                {
+                  "chord": "G",
+                  "lyrics": {
+                    "en": "let the echo guide",
+                    "es": "deja que el eco guíe"
+                  }
+                },
+                {
+                  "chord": "C",
+                  "lyrics": {
+                    "en": "we're not alone",
+                    "es": "no estamos solos"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "id": "song-002",
+    "title": {
+      "en": "Whispering Roots",
+      "es": "Raíces Susurrantes",
+      "ca": "Arrels Xiuxiuejants"
+    },
+    "authorId": "author-2",
+    "styleId": "flamenco",
+    "rhythm": "6/8",
+    "baseKey": "Am",
+    "singers": [],
+    "tags": ["ballad", "earthy"],
+    "song": {
+      "sections": [
+        {
+          "name": "Intro",
+          "lines": [
+            {
+              "blocks": [
+                {
+                  "chord": "Am",
+                  "lyrics": {
+                    "en": "Roots are whispering slow",
+                    "es": "Las raíces susurran despacio",
+                    "ca": "Les arrels xiuxiuegen a poc a poc"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Verse",
+          "lines": [
+            {
+              "blocks": [
+                {
+                  "chord": "Dm",
+                  "lyrics": {
+                    "en": "Night wind through the pines",
+                    "es": "Viento nocturno entre los pinos",
+                    "ca": "Vent de nit pels pins"
+                  }
+                },
+                {
+                  "chord": "E",
+                  "lyrics": {
+                    "en": "ancient stories turning",
+                    "es": "historias antiguas girando",
+                    "ca": "històries antigues girant"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/src/assets/mock/styles.json
+++ b/src/assets/mock/styles.json
@@ -1,0 +1,9 @@
+[
+  { "id": "pop", "label": "Pop" },
+  { "id": "rock", "label": "Rock" },
+  { "id": "rumba", "label": "Rumba" },
+  { "id": "balada", "label": "Balada" },
+  { "id": "latin", "label": "Latin" },
+  { "id": "flamenco", "label": "Flamenco" },
+  { "id": "others", "label": "Others" }
+]

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: false,
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,5 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- add core models, services, and Angular configuration for NoteDraftForge
- scaffold song list/detail and snapshot builder feature components with routing
- include mocked library JSON data for styles, authors, singers, and songs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693074b98350832091417a98d950c76f)