### PR TITLE
chore(ci): CI (lint/test/build) + Pages publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,9 @@ jobs:
 
       - name: Show npm version
         run: npm --version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-
-      - name: Show Node.js version
-        run: node --version
-
-      - name: Show npm version
-        run: npm --version
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -42,7 +37,7 @@ jobs:
       - name: Configure Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
-      
+
       - name: Upload GitHub Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: Test
         run: npm test -- --watch=false --browsers=ChromeHeadless
+
+      - name: Build
+        run: npm run build -- --configuration=production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -32,4 +37,26 @@ jobs:
         run: npm test -- --watch=false --browsers=ChromeHeadless
 
       - name: Build
-        run: npm run build -- --configuration=production
+        run: npm run build -- --configuration=production --base-href=/notedraftforge/
+
+      - name: Configure Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v5
+      
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/notedraftforge
+
+  deploy:
+    needs: ci
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: Test
+        run: npm test -- --watch=false --browsers=ChromeHeadless

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Show Node.js version
+        run: node --version
+
+      - name: Show npm version
+        run: npm --version

--- a/angular.json
+++ b/angular.json
@@ -40,7 +40,8 @@
                   "maximumWarning": "6KB"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "baseHref": "/notedraftforge/"
             },
             "development": {
               "buildOptimizer": false,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test",
-    "lint": "ng lint"
+    "lint": "npm run lint:tsc",
+    "lint:tsc": "tsc -p tsconfig.app.json --noEmit"
   },
   "dependencies": {
     "@angular/animations": "^21.0.3",

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,5 +5,6 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
Implements Issue #12: minimal CI pipeline and GitHub Pages deployment.

### What’s included
- GitHub Actions workflow runs on `push` and `pull_request`
- Uses Node version from `.nvmrc` (+ npm cache)
- Runs `npm ci`, lint, unit tests (ChromeHeadless) and production build
- Publishes the built app to GitHub Pages on merge to `main` (via `upload-pages-artifact` + `deploy-pages`)
- Sets `base-href` for `/notedraftforge/`

### How to verify
1. Merge this PR into `main`
2. Go to Actions → workflow “CI” and ensure `ci` + `deploy` jobs succeed
3. Open the GitHub Pages URL: `https://carloslg-dev.github.io/notedraftforge/`

Closes #12
